### PR TITLE
Serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "k256",
  "serde",
  "serde_json",
+ "serde_with",
  "sha2 0.10.1",
 ]
 
@@ -183,6 +184,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +360,12 @@ dependencies = [
  "crypto-mac",
  "digest 0.9.0",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -457,6 +505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +558,29 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b827f2113224f3f19a665136f006709194bdfdcb1fdc1e4b2b5cbac8e0cced54"
+dependencies = [
+ "rustversion",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,11 +50,10 @@ dependencies = [
  "ctrlc",
  "ecdsa",
  "elliptic-curve",
- "ethnum",
+ "ethereum-types",
  "k256",
  "serde",
  "serde_json",
- "serde_with",
  "sha2 0.10.1",
 ]
 
@@ -57,6 +62,18 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitvec"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -77,10 +94,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cfg-if"
@@ -143,6 +172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,41 +216,6 @@ checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
 dependencies = [
  "nix",
  "winapi",
-]
-
-[[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -277,10 +277,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethnum"
-version = "1.1.1"
+name = "ethbloom"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b40347dcad92b4dfeb9765c41c48503416daddf6dba55b74614dc035a43ed2"
+checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
 
 [[package]]
 name = "ff"
@@ -293,10 +314,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "fixed-hash"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -352,6 +385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,10 +401,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
+name = "impl-codec"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "indexmap"
@@ -432,6 +503,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
+name = "parity-scale-codec"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b44461635bbb1a0300f100a841e571e7d919c81c73075ef5d152ffdb521066"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c45ed1f39709f5a89338fab50e59816b2e8815f5bb58276e7ddf9afd495f73f8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +537,35 @@ dependencies = [
  "der",
  "spki",
  "zeroize",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "primitive-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -485,6 +611,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,10 +658,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.6"
+name = "rlp"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "ryu"
@@ -561,29 +724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b827f2113224f3f19a665136f006709194bdfdcb1fdc1e4b2b5cbac8e0cced54"
-dependencies = [
- "rustversion",
- "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +797,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,10 +818,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "uint"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -719,6 +921,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ k256 = "0.10.0"
 ethnum = "1.0.4"
 byteorder = "1.4.3"
 serde = { version = "1.0", features = ["derive"] }
+serde_with = "1.5.0"
 bincode = "1.3.3"
 clap = { version = "3.1.13", features = ["derive"] }
 ctrlc = "3.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,9 @@ sha2 = "0.10.0"
 ecdsa = "0.13.3"
 elliptic-curve = "0.11.6"
 k256 = "0.10.0"
-ethnum = "1.0.4"
+ethereum-types = "0.13.1"
 byteorder = "1.4.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_with = "1.5.0"
 bincode = "1.3.3"
 clap = { version = "3.1.13", features = ["derive"] }
 ctrlc = "3.2.2"

--- a/src/block.rs
+++ b/src/block.rs
@@ -6,7 +6,7 @@ use std::time::{SystemTime};
 use std::io::Cursor;
 use byteorder::{BigEndian, ReadBytesExt};
 
-use crate::Hash;
+use crate::{Hash, HashDef};
 use crate::transaction::{Transaction};
 
 /// This notation expresses the Proof-of-Work target as a coefficient/exponent format,
@@ -48,8 +48,13 @@ impl DifficultyBits {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlockHeader {
     version: u32, // 4 bytes: A version number to track software/protocol upgrades
+    
+    #[serde(with = "HashDef")]
     previous_block_hash: Hash, // 32 bytes: A reference to the hash of the previous (parent) block in the chain
+    
+    #[serde(with = "HashDef")]
     merkle_root: Hash, // 32 bytes: A hash of the root of the merkle tree of this block’s transactions
+    
     time_stamp: u64, // 4  (8 is ok?) bytes: The approximate creation time of this block (in seconds elapsed since Unix Epoch)
     difficulty_bits: DifficultyBits, // 4 bytes: The Proof-of-Work algorithm difficulty target for this block
     nonce: Option<u32>, // 4 bytes: A counter used for the Proof-of-Work algorithm
@@ -91,7 +96,7 @@ impl BlockHeader {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TransactionList {
     pub transactions: Vec<Transaction>,    
 }

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -86,7 +86,7 @@ impl BlockChain {
 	    return Err(TransactionError::OverSpend);
 	}
 
-	let miner_tip = tx_in_value_sum - tx_out_value_sum; // todo: use this for priority in mempool?
+	let _miner_tip = tx_in_value_sum - tx_out_value_sum; // todo: use this for priority in mempool?
 
 	self.mempool.push_back(transaction);
 	Ok(())
@@ -237,7 +237,7 @@ mod tests {
     fn add_to_mempool_invalid_missing_tx() {
 	let mut chain = BlockChain::new();
 
-	let transaction_hash = U256::from_words(0, 0); // this tx will not exist in the blockchain db
+	let transaction_hash = Hash::zero(); // this tx will not exist in the blockchain db
 	
 	let tx_in = TxIn::TxPrevious {
 	    tx_hash: transaction_hash, 
@@ -279,12 +279,14 @@ mod tests {
 	// A wallet would need to look it up by recipient public key or something like that
 	// decimal: 38321321692519566122529587483305535719886798403229990577862410369545149044829
 	// hex: 54B919753E5FC47F98A0574A2F5D5679726EAB8349DD943622C2DE14A497585D
-	let hi: u128 = 0x54_B9_19_75_3E_5F_C4_7F_98_A0_57_4A_2F_5D_56_79;
-	let low: u128 = 0x72_6E_AB_83_49_DD_94_36_22_C2_DE_14_A4_97_58_5D;
-	let transaction_hash = U256::from_words(hi, low);
-	let tx_hash_bytes = transaction_hash.to_be_bytes();
+	//let hi: u128 = 0x54_B9_19_75_3E_5F_C4_7F_98_A0_57_4A_2F_5D_56_79;
+	//let low: u128 = 0x72_6E_AB_83_49_DD_94_36_22_C2_DE_14_A4_97_58_5D;
+        let hash_bytes: [u8; 32] = [0x54, 0xB9, 0x19, 0x75, 0x3E, 0x5F, 0xC4, 0x7F, 0x98, 0xA0, 0x57, 0x4A, 0x2F, 0x5D, 0x56, 0x79,
+                                    0x72, 0x6E, 0xAB, 0x83, 0x49, 0xDD, 0x94, 0x36, 0x22, 0xC2, 0xDE, 0x14, 0xA4, 0x97, 0x58, 0x5D];
+	let transaction_hash = Hash::from(&hash_bytes);
+	//let tx_hash_bytes = transaction_hash.to_be_bytes();
 	
-	let sig = private_key.try_sign(&tx_hash_bytes).expect("should be able to sign the transaction hash here");
+	let sig = private_key.try_sign(&hash_bytes).expect("should be able to sign the transaction hash here");
 	let sig_as_bytes = sig.as_bytes().to_vec(); //TODO: is there a way to go right from &[u8] --> Box instead of through vec?
 	let unlocking_script = Script {ops: vec![StackOp::Bytes(sig_as_bytes.into_boxed_slice()), StackOp::Bytes(public_key_bytes)]};
 
@@ -331,12 +333,12 @@ mod tests {
 	// A wallet would need to look it up by recipient public key or something like that
 	// decimal: 38321321692519566122529587483305535719886798403229990577862410369545149044829
 	// hex: 54B919753E5FC47F98A0574A2F5D5679726EAB8349DD943622C2DE14A497585D
-	let hi: u128 = 0x54_B9_19_75_3E_5F_C4_7F_98_A0_57_4A_2F_5D_56_79;
-	let low: u128 = 0x72_6E_AB_83_49_DD_94_36_22_C2_DE_14_A4_97_58_5D;
-	let transaction_hash = U256::from_words(hi, low);
-	let tx_hash_bytes = transaction_hash.to_be_bytes();
+        let hash_bytes: [u8; 32] = [0x54, 0xB9, 0x19, 0x75, 0x3E, 0x5F, 0xC4, 0x7F, 0x98, 0xA0, 0x57, 0x4A, 0x2F, 0x5D, 0x56, 0x79,
+                                    0x72, 0x6E, 0xAB, 0x83, 0x49, 0xDD, 0x94, 0x36, 0x22, 0xC2, 0xDE, 0x14, 0xA4, 0x97, 0x58, 0x5D];
+	let transaction_hash = Hash::from(&hash_bytes);
+	//let tx_hash_bytes = transaction_hash.to_be_bytes();
 	
-	let sig = private_key.try_sign(&tx_hash_bytes).expect("should be able to sign the transaction hash here");
+	let sig = private_key.try_sign(&hash_bytes).expect("should be able to sign the transaction hash here");
 	let sig_as_bytes = sig.as_bytes().to_vec(); //TODO: is there a way to go right from &[u8] --> Box instead of through vec?
 	let unlocking_script = Script {ops: vec![StackOp::Bytes(sig_as_bytes.into_boxed_slice()), StackOp::Bytes(public_key_bytes)]};
 

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1,5 +1,4 @@
 use serde::{Serialize, Deserialize};
-use ethnum::U256;
 use std::collections::VecDeque;
 use k256::{Secp256k1};
 use ecdsa::{SigningKey, VerifyingKey};
@@ -152,7 +151,7 @@ impl BlockChain {
     /// if the blockchain is empty, i.e. we are spawning the genesis block, then the previous hash is simply 0
     fn get_previous_block_hash(&self) -> Hash {
 	if self.is_empty() {
-	    U256::ZERO
+	    Hash::zero()
 	} else {
 	    let previous_block = self.blocks.last().unwrap();
 	    previous_block.block_header.hash()

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,5 +1,4 @@
 use serde::{Serialize, Deserialize};
-use serde_with::{serde_as}; // needed for a hashmap of a remote type
 use std::collections::HashMap;
 
 use ecdsa::{SigningKey, VerifyingKey};
@@ -7,15 +6,13 @@ use k256::{Secp256k1};
 
 use crate::transaction::{Transaction, TxOut};
 use crate::block::{Block};
-use crate::{Hash, HashDef};
+use crate::{Hash};
 use crate::blockchain::{BlockChain};
 
 /// This struct holds a mapping from transaction hash to the transaction for all exisitng blocks
 /// It also keeps a record of how many blocks it has seen so far
-#[serde_as]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TransactionDataBase {
-    #[serde_as(as = "HashMap<HashDef, Transaction>")]    
     transactions_by_hash: HashMap<Hash, Transaction>,
     num_blocks_analyzed: u32,
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,3 +1,5 @@
+use serde::{Serialize, Deserialize};
+use serde_with::{serde_as}; // needed for a hashmap of a remote type
 use std::collections::HashMap;
 
 use ecdsa::{SigningKey, VerifyingKey};
@@ -5,13 +7,15 @@ use k256::{Secp256k1};
 
 use crate::transaction::{Transaction, TxOut};
 use crate::block::{Block};
-use crate::{Hash};
+use crate::{Hash, HashDef};
 use crate::blockchain::{BlockChain};
 
 /// This struct holds a mapping from transaction hash to the transaction for all exisitng blocks
 /// It also keeps a record of how many blocks it has seen so far
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TransactionDataBase {
+    #[serde_as(as = "HashMap<HashDef, Transaction>")]    
     transactions_by_hash: HashMap<Hash, Transaction>,
     num_blocks_analyzed: u32,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use serde::{Serialize, Deserialize};
-use ethnum::U256;
+use ethereum_types::H256;
 
 mod transaction;
 mod script;
@@ -7,11 +7,6 @@ mod block;
 pub mod blockchain;
 mod database;
 
-
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "U256")]
-pub struct HashDef(pub [u128; 2]);
-
-pub type Hash = U256;
+pub type Hash = H256;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use serde::{Serialize, Deserialize};
 use ethnum::U256;
 
 mod transaction;
@@ -6,6 +7,10 @@ mod block;
 pub mod blockchain;
 mod database;
 
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "U256")]
+pub struct HashDef(pub [u128; 2]);
 
 pub type Hash = U256;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-use serde::{Serialize, Deserialize};
-use ethereum_types::H256;
+use ethereum_types::U256;
 
 mod transaction;
 mod script;
@@ -7,6 +6,4 @@ mod block;
 pub mod blockchain;
 mod database;
 
-pub type Hash = H256;
-
-
+pub type Hash = U256;

--- a/src/script.rs
+++ b/src/script.rs
@@ -43,8 +43,7 @@ impl StackOp {
 /// the requirment for ownership of the utxo
 /// the locking script formally describes the conditions needed to spend a given UTXO,
 /// Usually requiring a signature from a specific address
-#[derive(Debug, Clone)]
-//#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Script {
     pub ops: Vec<StackOp>
 }

--- a/src/script.rs
+++ b/src/script.rs
@@ -5,7 +5,6 @@ use sha2::{Sha256, Digest};
 use ecdsa::signature::{Signer, Verifier, Signature}; // trait in scope for signing a message
 
 use elliptic_curve::sec1::{EncodedPoint};
-use ethnum::U256;
 use bincode;
 use std::io::Cursor;
 use byteorder::{BigEndian, ReadBytesExt};

--- a/src/script.rs
+++ b/src/script.rs
@@ -6,11 +6,6 @@ use ecdsa::signature::{Signer, Verifier, Signature}; // trait in scope for signi
 
 use elliptic_curve::sec1::{EncodedPoint};
 use bincode;
-use std::io::Cursor;
-use byteorder::{BigEndian, ReadBytesExt};
-
-
-use crate::Hash;
 
 /// enum to hold the various Script operations and their associated values
 /// we derive Serialize and Deserialize so that we can turn the StackOp into bytes during hashing
@@ -29,7 +24,6 @@ pub enum StackOp {
     OpVerify, // mark the transaction as invalid if the top value on the stack is not true
     OpEqVerify, // combine OpEq and OpVerify in one go.
 }
-
 
 impl StackOp {
     pub fn to_be_bytes(&self) -> Vec<u8> {
@@ -165,8 +159,8 @@ pub fn execute_scripts(unlocking_script: &Script, locking_script: &Script, tx_pr
 				let signature: ecdsa::Signature<Secp256k1> = Signature::from_bytes(bytes_sig).expect("problem deserializing signature");
 				// the "message" that was signed was the transaction of the previous hash that
 				// led to the locking script that we are currently trying to unlock.
-				let verified = public_key.verify(tx_previous_hash, &signature);
-				if let Ok(verified) = verified {
+				let verified_res = public_key.verify(tx_previous_hash, &signature);
+				if let Ok(_) = verified_res {
 				    stack.push(StackOp::Bool(true));
 				} else {
 				    stack.push(StackOp::Bool(false));				    

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,9 +1,7 @@
 use serde::{Serialize, Deserialize};
 //use ecdsa::{SigningKey, VerifyingKey};
 use sha2::{Sha256, Digest};
-use k256::{Secp256k1};
-//use ethnum::U256;
-//use elliptic_curve::sec1::{EncodedPoint};
+//use k256::{Secp256k1};
 
 use std::io::Cursor;
 use byteorder::{BigEndian, ReadBytesExt};
@@ -51,7 +49,9 @@ impl Transaction {
 	for tx_in in &self.tx_ins {
 	    match tx_in {
 		TxIn::TxPrevious{tx_hash, tx_out_index, unlocking_script, sequence} => {
-		    hasher.update(tx_hash.to_fixed_bytes());
+                    for i in 0..4 {
+		        hasher.update(tx_hash.0[i].to_be_bytes());
+                    }
 		    hasher.update(tx_out_index.to_be_bytes());
 		    for op in &unlocking_script.ops {
 			hasher.update(op.to_be_bytes());
@@ -79,7 +79,7 @@ impl Transaction {
     pub fn hash(&self) -> Hash {
 	//let hash_vecs: Vec<u8> = hasher.finalize().to_vec();
 	let hash_vec: Vec<u8> = self.hash_to_bytes();
-        Hash::from_slice(&hash_vec)
+        Hash::from(&hash_vec[..])
     }
 
 }
@@ -139,6 +139,7 @@ mod tests {
 	// change to StackOp enum or something? interesting
 	// Note2: after changing a type from u32 to usize i think it changed again too lol
 	let hash = transaction.hash();
-	assert_eq!(hash, Hash::from_words(28996938242674037981331829445228525750_u128, 14191864817386241420276944889147662564_u128));
+        // TODO: fix
+	assert_eq!(hash, Hash::zero()); //Hash::from_words(28996938242674037981331829445228525750_u128, 14191864817386241420276944889147662564_u128));
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,22 +1,25 @@
+use serde::{Serialize, Deserialize};
 //use ecdsa::{SigningKey, VerifyingKey};
 use sha2::{Sha256, Digest};
 use k256::{Secp256k1};
-use ethnum::U256;
+//use ethnum::U256;
 //use elliptic_curve::sec1::{EncodedPoint};
 
 use std::io::Cursor;
 use byteorder::{BigEndian, ReadBytesExt};
 
 use crate::script::{Script, StackOp};
-use crate::Hash;
+use crate::{Hash, HashDef};
 
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TxIn {
     // A transaction input can either come from a previous transaction output,
     // or if it is part of a block reward, then can be a coinbase
     TxPrevious {
+        #[serde(with = "HashDef")]        
 	tx_hash: Hash, // Hash of the transaction that we are getting this input from
+        
 	tx_out_index: usize,// The index of the tx_out within the transaction
 	unlocking_script: Script, // AKA: ScriptSig, but lets follow Mastering Bitcoin's convention
 	sequence: u32, // TODO: what is this haha
@@ -27,7 +30,7 @@ pub enum TxIn {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TxOut {
     pub value: u32, // number of satoshis 
     pub locking_script: Script, // AKA: ScriptPubKey, but following Master Bitcoin's convention
@@ -84,7 +87,7 @@ impl Transaction {
 	let mut rdr = Cursor::new(hash_vecs);
 	let hi = rdr.read_u128::<BigEndian>().unwrap();
 	let low = rdr.read_u128::<BigEndian>().unwrap();
-        U256::from_words(hi, low)
+        Hash::from_words(hi, low)
     }
 
 }
@@ -144,6 +147,6 @@ mod tests {
 	// change to StackOp enum or something? interesting
 	// Note2: after changing a type from u32 to usize i think it changed again too lol
 	let hash = transaction.hash();
-	assert_eq!(hash, U256::from_words(28996938242674037981331829445228525750_u128, 14191864817386241420276944889147662564_u128));
+	assert_eq!(hash, Hash::from_words(28996938242674037981331829445228525750_u128, 14191864817386241420276944889147662564_u128));
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -131,15 +131,13 @@ mod tests {
 
 	// note: this is simply the hash that comes out when i presently run it.
 	// This will at least show if something changes unexpectedly in the future
-	// 9867146778677399561412053178184496996625184432557161352426664471158288654564 decimal
-	// 15D09B6F36496CB1D7693954A23078B60AAD40F539D3503C52A314892AB1A0E4 hex
-
-
-	// Note: adter working on the code more (and the script/stack stuff in particular). This now fails hmm
-	// change to StackOp enum or something? interesting
-	// Note2: after changing a type from u32 to usize i think it changed again too lol
+	// 34955240534511464281001754460162170822162357866488741313605570467957795050853 decimal
+	// 4D47F70BE4C85658925EC886B1C362EBDBC96D9E41F1DC55520169815A11D565 hex
+        // Note: this has changed multiple times as i impliment, so is it even a good test..?
 	let hash = transaction.hash();
-        // TODO: fix
-	assert_eq!(hash, Hash::zero()); //Hash::from_words(28996938242674037981331829445228525750_u128, 14191864817386241420276944889147662564_u128));
+        println!("hash = {:?}", hash);
+        let answer = Hash::from([0x4D, 0x47, 0xF7, 0x0B, 0xE4, 0xC8, 0x56, 0x58, 0x92, 0x5E, 0xC8, 0x86, 0xB1, 0xC3, 0x62, 0xEB, 0xDB,
+                                 0xC9, 0x6D, 0x9E, 0x41, 0xF1, 0xDC, 0x55, 0x52, 0x01, 0x69, 0x81, 0x5A, 0x11, 0xD5, 0x65]);
+	assert_eq!(hash, answer);
     }
 }


### PR DESCRIPTION
- the goal was to allow reading and writing to disk for chain persistence for the client. 
- the underlying U256 type that I was using did not implement Serialize/Deserialize from serde, so I ended up changing the U256 to be the one from the primitive_types crate. This required a pretty decent size refactor to all the hashing code, but ended up working pretty well it seems.
-  The actual reading and writing is pretty simple. Use serde to turn the chain into a json string, then write the string to disk normally. And to read, simply use serde_json::from_reader()
- I think the cli could be a bit smoother/better for these operations, but it works fine for now.